### PR TITLE
Fix bug handling spaces in fasta header lines

### DIFF
--- a/.ci/install_dependencies.sh
+++ b/.ci/install_dependencies.sh
@@ -82,7 +82,7 @@ cp -s racon-git/build/bin/racon .
 cd $install_root
 git clone https://github.com/iqbal-lab-org/viridian.git
 cd viridian
-git checkout a0915ee7dc0ec815ea8bf50f28ced8a51b451bd7
+git checkout ee7f80a7b200eeb49cec968014ebfccca9cbfaad
 pip3 install .
 
 #________________________ mummer ____________________________#

--- a/tests/data/utils/load_single_seq_fasta.ok.fa
+++ b/tests/data/utils/load_single_seq_fasta.ok.fa
@@ -1,2 +1,2 @@
->seq
+>seq foo
 ACGT

--- a/tests/sample_reads_test.py
+++ b/tests/sample_reads_test.py
@@ -13,7 +13,7 @@ from viridian_workflow import sample_reads
 def make_test_ref_genome(outfile):
     ref = "".join(random.choices(["A", "C", "G", "T"], k=1000))
     with open(outfile, "w") as f:
-        print(">ref", file=f)
+        print(">ref foo", file=f)
         print(ref, file=f)
     return ref
 

--- a/viridian_workflow/utils.py
+++ b/viridian_workflow/utils.py
@@ -68,4 +68,6 @@ def load_single_seq_fasta(infile):
         raise Exception(
             f"Expected exatcly 1 sequence in {infile} but got {len(d)} sequences"
         )
-    return list(d.values())[0]
+    ref = list(d.values())[0]
+    ref.id = ref.id.split()[0]
+    return ref


### PR DESCRIPTION
fixes bug where the pipeline would crash if spaces in names of sequences in fasta files