### PR TITLE
Expose hard-coded numbers, adding new relevant options

### DIFF
--- a/viridian_workflow/__main__.py
+++ b/viridian_workflow/__main__.py
@@ -156,6 +156,27 @@ def main(args=None):
         help="Target coverage for amplicon depth normalisation [%(default)s]",
         metavar="INT",
     )
+    subparser_run_one_sample.add_argument(
+        "--min_sample_depth",
+        type=int,
+        default=10,
+        help="Minimum coverage required during amplicon depth normalisation. Any amplicon with depth below this is failed and it will have no consensus sequence generated [%(default)s]",
+        metavar="INT",
+    )
+    subparser_run_one_sample.add_argument(
+        "--max_percent_amps_fail",
+        type=float,
+        default=50.0,
+        help="Maximum percent of amplicons allowed to fail during read sampling or making consensus for each amplicon. The pipeline is stopped as soon as too many failed amplicons are detected [%(default)s]",
+        metavar="FLOAT",
+    )
+    subparser_run_one_sample.add_argument(
+        "--max_cons_n_percent",
+        type=float,
+        default=50.0,
+        help="Maximum allowed percentage of Ns in the consensus sequence from Viridian. Pipeline is stopped if too many Ns [%(default)s]",
+        metavar="FLOAT",
+    )
     subparser_run_one_sample.set_defaults(
         func=viridian_workflow.tasks.run_one_sample.run
     )

--- a/viridian_workflow/one_sample_pipeline.py
+++ b/viridian_workflow/one_sample_pipeline.py
@@ -33,6 +33,9 @@ class Pipeline:
         keep_bam=False,
         target_sample_depth=1000,
         sample_name="sample",
+        min_sample_depth=10,
+        max_percent_amps_fail=50.0,
+        viridian_cons_max_n_percent=50.0,
         command_line_args=None,
     ):
         self.tech = tech
@@ -47,8 +50,9 @@ class Pipeline:
         self.keep_bam = keep_bam
         self.target_sample_depth = target_sample_depth
         self.sample_name = sample_name
-        self.viridian_cons_max_n_percent = 50.0
-        self.max_percent_amps_fail = 50.0
+        self.max_percent_amps_fail = max_percent_amps_fail
+        self.min_sample_depth = min_sample_depth
+        self.viridian_cons_max_n_percent = viridian_cons_max_n_percent
         self.command_line_args = command_line_args
         self.start_time = None
         self.amplicon_scheme_name_to_tsv = None
@@ -188,6 +192,7 @@ class Pipeline:
             sample_outprefix,
             self.amplicon_bed,
             target_depth=self.target_sample_depth,
+            min_sampled_depth_for_pass=self.min_sample_depth,
         )
         self.log_dict["read_sampling"] = utils.load_json(f"{sample_outprefix}.json")
         self.sampled_bam = self.sampler.bam_out

--- a/viridian_workflow/tasks/run_one_sample.py
+++ b/viridian_workflow/tasks/run_one_sample.py
@@ -23,5 +23,8 @@ def run(options):
         keep_bam=options.keep_bam,
         target_sample_depth=options.target_sample_depth,
         sample_name=options.sample_name,
+        min_sample_depth=options.min_sample_depth,
+        max_percent_amps_fail=options.max_percent_amps_fail,
+        viridian_cons_max_n_percent=options.max_cons_n_percent,
         command_line_args=options,
     )


### PR DESCRIPTION
There were 3 hard-coded numbers in the pipeline. Expose them on the command line (with defaults the same as what was in the code before). New options: `--min_sample_depth --max_percent_amps_fail --max_cons_n_percent`