### PR TITLE
Illumina unpaired

### DIFF
--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -72,47 +72,26 @@ def test_check_tech_and_reads_options():
     options.reads2 = None
     assert f(options)
 
-    options = mock.Mock()
-    options.reads_bam = None
-    options.reads = None
-    options.reads1 = None
-    options.reads2 = None
-    options.tech = None
-    options.ena_run = None
-    with pytest.raises(Exception):
-        f(options)
-    options.tech = "illumina"
-    with pytest.raises(Exception):
-        f(options)
-    options.reads = "r.fq"
-    with pytest.raises(Exception):
-        f(options)
-    options.reads1 = "r1.fq"
-    with pytest.raises(Exception):
-        f(options)
-    options.reads = None
-    with pytest.raises(Exception):
-        f(options)
-    options.reads2 = "r2.fq"
-    assert f(options)
-
-    options = mock.Mock()
-    options.reads_bam = None
-    options.reads = None
-    options.reads1 = None
-    options.reads2 = None
-    options.tech = None
-    options.ena_run = None
-    options.tech = "iontorrent"
-    with pytest.raises(Exception):
-        f(options)
-    options.reads = "r.fq"
-    assert f(options)
-    options.reads1 = "r1.fq"
-    with pytest.raises(Exception):
-        f(options)
-    options.reads2 = "r2.fq"
-    with pytest.raises(Exception):
-        f(options)
-    options.reads = None
-    assert f(options)
+    for tech in ["illumina", "iontorrent"]:
+        options = mock.Mock()
+        options.reads_bam = None
+        options.reads = None
+        options.reads1 = None
+        options.reads2 = None
+        options.tech = None
+        options.ena_run = None
+        with pytest.raises(Exception):
+            f(options)
+        options.tech = tech
+        with pytest.raises(Exception):
+            f(options)
+        options.reads = "r.fq"
+        assert f(options)
+        options.reads1 = "r1.fq"
+        with pytest.raises(Exception):
+            f(options)
+        options.reads = None
+        with pytest.raises(Exception):
+            f(options)
+        options.reads2 = "r2.fq"
+        assert f(options)

--- a/viridian/__main__.py
+++ b/viridian/__main__.py
@@ -95,7 +95,7 @@ def main(args=None):
         choices=tech_choices,
         help=f"Sequencing technology, currently supported: {','.join(tech_choices)}",
     )
-    reads_epilog = "IMPORTANT: --tech, --outdir are REQUIRED. Reads files are required, and depend on the --tech option. Use one of: 1) '--tech ont|iontorrent --reads reads.fq'; 2) '--tech illumina|iontorrent --reads1 reads1.fq --reads2 reads2.fq'; 3) (with any tech) --reads_bam reads.bam"
+    reads_epilog = "IMPORTANT: --tech, --outdir are REQUIRED. Reads files are required, and depend on the --tech option. Use one of: 1) '--tech illumina|ont|iontorrent --reads reads.fq'; 2) '--tech illumina|iontorrent --reads1 reads1.fq --reads2 reads2.fq'; 3) (with any tech) --reads_bam reads.bam"
 
     # --------------------------- ref options --------------------------------
     ref_parser = argparse.ArgumentParser(add_help=False)

--- a/viridian/constants.py
+++ b/viridian/constants.py
@@ -8,6 +8,12 @@ TECH2FRS = {
     "iontorrent": 0.5,
 }
 
+TECH2MINIMAP_X = {
+    "illumina": "-x sr",
+    "ont": "-x map-ont",
+    "iontorrent": "-x sr",
+}
+
 CYLON_TECH = {
     "illumina": "illumina",
     "ont": "ont",

--- a/viridian/one_sample_pipeline.py
+++ b/viridian/one_sample_pipeline.py
@@ -111,6 +111,8 @@ class Pipeline:
         if self.gzip_files:
             self.json_log_file += ".gz"
             self.final_masked_fasta += ".gz"
+        self.minimap_x_opt = constants.TECH2MINIMAP_X[self.tech]
+
 
     def set_command_line_dict(self):
         # Make a dict of the command line options to go in the JSON output file.
@@ -327,6 +329,7 @@ class Pipeline:
             reads2=self.reads_file2,
             debug=self.debug,
             sample_name=self.sample_name,
+            minimap_x_opt=self.minimap_x_opt,
         )
         return True
 
@@ -499,7 +502,10 @@ class Pipeline:
     def self_qc(self):
         logging.info("Start QC using reads mapped to consensus")
         self.pileups = self.read_sampler.pileups(
-            self.final_unmasked_fasta, self.qc_bams_dir, self.debug
+            self.final_unmasked_fasta,
+            self.qc_bams_dir,
+            minimap_x_opt=self.minimap_x_opt,
+            debug=self.debug,
         )
         if len(self.pileups) == 0:
             self.add_errors_to_log("No pileup data generated")

--- a/viridian/one_sample_pipeline.py
+++ b/viridian/one_sample_pipeline.py
@@ -113,7 +113,6 @@ class Pipeline:
             self.final_masked_fasta += ".gz"
         self.minimap_x_opt = constants.TECH2MINIMAP_X[self.tech]
 
-
     def set_command_line_dict(self):
         # Make a dict of the command line options to go in the JSON output file.
         # The tests don't use argparse (they use Mock), which means convert to dict

--- a/viridian/reads.py
+++ b/viridian/reads.py
@@ -439,7 +439,7 @@ class ReadSampler:
             os.path.join(self.cylon_dir, "manifest.json"), self.cylon_fa_manifest
         )
 
-    def pileups(self, consensus_fasta, tmp_outdir, debug=False):
+    def pileups(self, consensus_fasta, tmp_outdir, minimap_x_opt=None, debug=False):
         pileups = {}
         os.mkdir(tmp_outdir)
         for amplicon, reads_dict in self.qc_reads_files.items():
@@ -454,6 +454,7 @@ class ReadSampler:
                     consensus_fasta,
                     reads1,
                     reads2,
+                    minimap_x_opt=minimap_x_opt,
                     debug=debug,
                 )
 

--- a/viridian/utils.py
+++ b/viridian/utils.py
@@ -103,22 +103,21 @@ def check_tech_and_reads_options(args):
             raise Exception("--decontam is not compatible with --reads_bam")
         return True
 
-    if args.tech == "illumina" and not (reads1 and reads2 and not reads):
-        raise Exception(
-            "For Illumina tech, must provide --reads1, --reads2 and not provide --reads"
-        )
-    elif args.tech == "ont" and not (reads and not reads1 and not reads2):
-        raise Exception(
-            "For ont tech, must provide --reads, and provide --reads1, --reads2"
-        )
-    elif args.tech == "iontorrent":
+    if args.tech == "ont":
+        if not (reads and not reads1 and not reads2):
+            raise Exception(
+                "For ont tech, must provide --reads, and provide --reads1, --reads2"
+            )
+    elif args.tech in ["illumina", "iontorrent"]:
         ok1 = reads and not (reads1 or reads2)
         ok2 = reads1 and reads2 and not reads
         print(reads, reads1, reads2, ok1, ok2)
         if not (ok1 or ok2):
             raise Exception(
-                "For iontorrent tech, must provide either --reads, or alternatively provide both --reads1, --reads2"
+                "For illumina/iontorrent tech, must provide either --reads, or alternatively provide both --reads1, --reads2"
             )
+    else:
+        raise NotImplementedError()
 
     return True
 


### PR DESCRIPTION
Allow Illumina reads to be unpaired.

Also tidy up using minimap2 preset `-x` option for each tech, so is `-x sr` for illumina/iontorrent and `-x map-ont` for ont. Was previously using  `-x map-ont` for unpaired iontorrent.