### PR TITLE
ENA fixes

### DIFF
--- a/viridian/ena.py
+++ b/viridian/ena.py
@@ -61,18 +61,12 @@ def fastq_ftp_string_to_files(fastq_ftp_str):
 
 
 def wanted_reads_files(all_files, platform):
-    if platform == "ILLUMINA":
-        if len(all_files["paired"]) != 2:
-            raise Exception(
-                "Need paired files for Illumina but did not get pair of files"
-            )
-        return None, *all_files["paired"]
-    elif platform == "OXFORD_NANOPORE":
+    if platform == "OXFORD_NANOPORE":
         # Just in case there were multiple files and the first two happened
         # to be called foo_1.fastq.gz, foo_2.fastq.gz, assume all reads
         # are unpaired
         return all_files["unpaired"] + all_files["paired"], None, None
-    elif platform == "ION_TORRENT":
+    elif platform in ["ILLUMINA", "ION_TORRENT"]:
         if len(all_files["paired"]) == 2:
             return None, *all_files["paired"]
         else:

--- a/viridian/one_sample_pipeline.py
+++ b/viridian/one_sample_pipeline.py
@@ -111,7 +111,6 @@ class Pipeline:
         if self.gzip_files:
             self.json_log_file += ".gz"
             self.final_masked_fasta += ".gz"
-        self.minimap_x_opt = constants.TECH2MINIMAP_X[self.tech]
 
     def set_command_line_dict(self):
         # Make a dict of the command line options to go in the JSON output file.
@@ -328,7 +327,7 @@ class Pipeline:
             reads2=self.reads_file2,
             debug=self.debug,
             sample_name=self.sample_name,
-            minimap_x_opt=self.minimap_x_opt,
+            minimap_x_opt=constants.TECH2MINIMAP_X[self.tech],
         )
         return True
 
@@ -503,7 +502,7 @@ class Pipeline:
         self.pileups = self.read_sampler.pileups(
             self.final_unmasked_fasta,
             self.qc_bams_dir,
-            minimap_x_opt=self.minimap_x_opt,
+            minimap_x_opt=constants.TECH2MINIMAP_X[self.tech],
             debug=self.debug,
         )
         if len(self.pileups) == 0:


### PR DESCRIPTION
* bug fix, where when downloading reads we don't know the sequencing tech until after they are downloaded. Was causing key error (#108)
* allow downloaded Illumina reads to be unpaired instead of enforcing paired

Fixes #108 
